### PR TITLE
Look for data on the element rather than document.body

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -67,7 +67,7 @@
             this.options.message_attribute);
         var body_attribute = $(document.body).data(
             this.options.message_attribute);
-        var fallback_attribute = $(document.body).data(
+        var fallback_attribute = $(this.element).data(
             this.options.fallback_message_attribute);
 
         if (this.options.message_attribute && element_attribute) {


### PR DESCRIPTION
The fallback_message_attribute will be stored on the element, but we are
looking for it on the body